### PR TITLE
Duplicate Nginx Config Removal

### DIFF
--- a/roles/laravel-setup/tasks/main.yml
+++ b/roles/laravel-setup/tasks/main.yml
@@ -35,19 +35,6 @@
   when: disable_default_pool | default(true)
   notify: reload php-fpm
 
-- name: Create Laravel Nginx configuration
-  template:
-    src: nginx.conf.j2
-    dest: "/etc/nginx/sites-available/{{ item.key }}.conf"
-    owner: root
-    group: root
-    mode: '0644'
-  loop: "{{ wordpress_sites | default({}) | dict2items | selectattr('value.type', 'defined') | selectattr('value.type', 'equalto', 'laravel') | list }}"
-  loop_control:
-    label: "{{ item.key }}"
-  notify: reload nginx
-  tags: laravel-setup-nginx
-
 - import_tasks: nginx.yml
   tags: laravel-setup-nginx
 


### PR DESCRIPTION
This pull request makes a change to the Laravel setup process by removing the inline task for creating Nginx configuration files and replacing it with an imported task file. This simplifies the `main.yml` file and centralizes the Nginx-related logic.

### Laravel setup changes:
* Removed the inline task for creating Laravel Nginx configuration files in `roles/laravel-setup/tasks/main.yml` and replaced it with an import of `nginx.yml`. This centralizes Nginx configuration management and reduces duplication.